### PR TITLE
Update package.js to support newer dependencies

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,17 +1,11 @@
 Package.describe({
   name: 'quave:reloader',
-  version: '2.0.3',
+  version: '2.0.4',
   summary: 'More control over hot code push reloading',
   git: 'https://github.com/quavedev/reloader/',
 });
 
-Cordova.depends({
-  'cordova-plugin-splashscreen': '5.0.3',
-});
-
 Package.onUse(function(api) {
-  api.versionsFrom('1.10.2');
-
   api.use(
     ['ecmascript', 'reload', 'reactive-var', 'tracker', 'launch-screen'],
     'client'


### PR DESCRIPTION
removed the outdated Cordova-plugin-splashscreen dependency and also the versionsFrom so that the reloader can be used in the latest version of meteor.js (2.14 onwards)